### PR TITLE
fix: Make Docker Hub description update non-blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,10 @@ jobs:
         run: |
           cosign sign --yes ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@${{ steps.build.outputs.digest }}
 
+      # TODO: Fix DOCKERHUB_TOKEN permissions to allow description updates
+      # Current token only has push access, needs "Read, Write, Delete" scope
       - name: Update Docker Hub description
+        continue-on-error: true
         if: github.ref == 'refs/heads/main'
         uses: peter-evans/dockerhub-description@v5
         with:


### PR DESCRIPTION
## Summary
- Add `continue-on-error: true` to Docker Hub description update step
- Add TODO comment documenting the token permission issue
- Prevents the Publish Docker job from failing due to missing API permissions

## Background
The `DOCKERHUB_TOKEN` secret doesn't have permission to update repository descriptions (only push access). This caused the Publish Docker job to fail even though the image was successfully pushed and signed.

## Fix Required Later
Update the Docker Hub access token with "Read, Write, Delete" scope to properly fix this issue.

## Test plan
- [ ] CI passes with non-blocking step
- [ ] Verify Docker image still publishes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD workflow resilience by enabling error-tolerant behavior for Docker Hub updates, allowing the continuous integration pipeline to proceed even if the description update step fails.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->