### PR TITLE
docs: Refresh README with updated content and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Run Claude Code CLI in Docker - no local installation needed. Full MCP support, 
 - Docker commands work (socket is mounted)
 - SSH keys and git config just work
 - Homebrew included - easy migration from local macOS setup
+- Works on Linux, macOS, and Windows
 - **Safer `--dangerously-skip-permissions`** - container isolation means Claude can only access your project, not your whole system
 
 ## Quick Start


### PR DESCRIPTION
## Summary
- Complete README refresh to be more user-friendly and accurate

## Changes
- Add "Why dclaude?" section to hook users
- Move Quick Start up front with NPM as recommended install
- Fix outdated info:
  - Build commands now use `docker/` context
  - Persistent is now default (`DCLAUDE_RM=false`)
  - macOS can have host networking (OrbStack/Docker Desktop beta)
  - Project structure reflects `docker/` directory
- Simplify and consolidate sections (1086 → 307 lines)
- More conversational, user-focused tone
- Add Docker Hub and npm badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Project renamed and rebranded to "dclaude" with updated header/badges.
  * Messaging refocused on container-native, no-local-install workflows and persistent sessions.
  * Condensed setup and usage content; simplified Quick Start, networking, and config instructions.
  * New/relocated quick-reference sections (Basic Usage, Homebrew, GitHub CLI, Networking, Config Mounting).
  * Environment and configuration guidance reorganized into concise reference form.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->