### PR TITLE
ci: Skip Docker publish when only non-Docker files change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,24 @@ env:
   IMAGE_NAME: alanbem/dclaude
 
 jobs:
+  changes:
+    name: Detect Changes
+    runs-on: ubuntu-latest
+    outputs:
+      docker: ${{ steps.filter.outputs.docker }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Check for Docker-related changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docker:
+              - 'docker/**'
+              - 'VERSION'
+
   lint:
     name: Lint
     runs-on: ubuntu-latest
@@ -139,8 +157,11 @@ jobs:
   publish-docker:
     name: Publish Docker
     runs-on: ubuntu-latest
-    needs: [lint, gitleaks, semgrep, build-and-scan]
-    if: github.event_name != 'pull_request'
+    needs: [lint, gitleaks, semgrep, build-and-scan, changes]
+    # Run on tags (releases) OR when docker files changed on main branch
+    if: |
+      github.event_name != 'pull_request' &&
+      (startsWith(github.ref, 'refs/tags/') || needs.changes.outputs.docker == 'true')
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
## Summary
- Add path detection to skip the ~11-minute multi-arch Docker build when only docs or other non-Docker files change

## Changes
- Add `changes` job using `dorny/paths-filter@v3`
- Publish Docker only when `docker/**` or `VERSION` changes
- Always publish on tags (releases)

## Test plan
- [ ] Verify this PR doesn't trigger Docker publish (no docker files changed)
- [ ] Merge and verify docs-only changes skip Docker publish on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)