### PR TITLE
ci: Use 'latest' only for releases, 'edge' for main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,12 +198,16 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            # main branch -> 'edge' tag (bleeding edge)
+            type=raw,value=edge,enable={{is_default_branch}}
             type=ref,event=pr
+            # releases -> version tags (1.2.3, 1.2, 1)
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable={{is_default_branch}}
+            # releases -> 'latest' tag (stable)
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
+            # all builds -> sha tag for pinning
             type=sha,prefix=sha-
 
       - name: Build and push Docker image

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -746,6 +746,19 @@ make test            # Run tests
 make push            # Push to registries (requires auth)
 ```
 
+### Docker Image Tags
+
+| Tag | When Updated | Use Case |
+|-----|--------------|----------|
+| `latest` | Release tags only (`v1.2.3`) | Stable, recommended for most users |
+| `edge` | Every main branch push | Bleeding edge, latest features |
+| `1.2.3` | Release tag `v1.2.3` | Pin to specific version |
+| `1.2` | Release tag `v1.2.x` | Pin to minor version |
+| `1` | Release tag `v1.x.x` | Pin to major version |
+| `sha-abc123` | Every build | Pin to exact commit |
+
+**Key principle:** `latest` = stable releases only, `edge` = bleeding edge.
+
 ### Debug Issues
 ```bash
 DCLAUDE_DEBUG=true dclaude    # Enable debug output


### PR DESCRIPTION
## Summary
- `latest` tag now only updates on release tags (stable)
- `edge` tag updates on every main branch push (bleeding edge)

## Docker Tag Strategy

| Tag | When Updated | Use Case |
|-----|--------------|----------|
| `latest` | Release tags only | Stable, recommended |
| `edge` | Main branch pushes | Bleeding edge |
| `1.2.3`, `1.2`, `1` | Release tags | Version pinning |
| `sha-xxx` | Every build | Exact commit pinning |

## Test plan
- [ ] Merge and verify main branch push creates `edge` tag (not `latest`)
- [ ] Create release tag and verify `latest` is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added comprehensive guide explaining Docker image tag conventions, including latest, edge, version-specific, and commit-accurate tags.

* **Chores**
  * Updated Docker image tagging behavior in CI/CD pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->