### PR TITLE
fix: Upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,9 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
+
       - name: Extract version from tag
         id: version
         run: |


### PR DESCRIPTION
## Summary
- Adds npm upgrade step before publishing to npm
- Node.js 22 ships with npm 10.9.4, but OIDC trusted publishing requires npm 11.5.1+
- Fixes the 404 error when publishing v0.0.1 to npm

## Test plan
- [ ] CI passes
- [ ] Release v0.0.2 to verify npm publish works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD pipeline configuration to ensure more reliable package preparation during the publishing process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->