### PR TITLE
feat: add `dclaude git` command for git identity configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,96 @@ The `handle_ssh_auth()` function provides flexible SSH authentication via `DCLAU
 - **SOLVED**: macOS Docker Desktop permissions via socat proxy in entrypoint script
 - Entrypoint automatically creates proxy socket owned by claude user when needed
 
+#### macOS SSH Proxy Architecture
+
+On macOS, SSH agent forwarding requires a separate proxy container due to Docker Desktop permission issues:
+
+1. **Proxy container** (`dclaude-ssh-proxy-<uid>`) runs socat to bridge the host's SSH agent socket
+2. **Shared volume** (`dclaude-ssh-proxy`) holds the proxied socket at `/tmp/ssh-proxy/agent`
+3. **Main container** mounts this volume read-only and sets `SSH_AUTH_SOCK=/tmp/ssh-proxy/agent`
+
+**Key insight**: The proxy forwards keys dynamically - once running, any keys added to the host agent are immediately available in the container. The proxy doesn't need to restart when you `ssh-add` new keys.
+
+#### Troubleshooting: SSH Agent Not Working
+
+If SSH operations fail with "Permission denied (publickey)" after loading keys on the host:
+
+**Symptoms:**
+- `ssh-add -l` on host shows keys loaded
+- `ssh-add -l` in container shows "Error connecting to agent: Connection refused"
+- Socket file exists at `/tmp/ssh-proxy/agent` but nothing is listening
+
+**Cause:** The SSH proxy container died or was never started for this session.
+
+**Fix:** Restart the proxy container without restarting dclaude:
+
+```bash
+# From the HOST (not inside dclaude):
+docker run -d \
+    --name "dclaude-ssh-proxy-$(id -u)" \
+    -v "/run/host-services/ssh-auth.sock:/run/host-services/ssh-auth.sock:ro" \
+    -v "dclaude-ssh-proxy:/tmp/ssh-proxy" \
+    --rm \
+    alpine:3.19 sh -c '
+        apk add --no-cache socat >/dev/null 2>&1
+        rm -f /tmp/ssh-proxy/agent
+        socat UNIX-LISTEN:/tmp/ssh-proxy/agent,fork,mode=660 \
+              UNIX-CONNECT:/run/host-services/ssh-auth.sock
+    '
+```
+
+After this, `ssh-add -l` inside the container should show your keys immediately.
+
+**Note:** This only applies to macOS. On Linux, the SSH agent socket is mounted directly.
+
+## Git Configuration
+
+### The `dclaude git` Command
+
+Configure git identity (name/email) for commits made inside the container.
+
+**Usage:**
+```bash
+dclaude git
+```
+
+**Flow:**
+1. Checks if git config already exists in volume
+2. If exists, shows current config and asks if you want to update
+3. Checks host's git config (`~/.gitconfig`)
+4. If found on host, offers to copy to container
+5. Otherwise, prompts for manual input
+6. Saves to persistent volume
+
+**Example:**
+```
+$ dclaude git
+
+Git Configuration
+─────────────────
+Found on host:
+  Name:  Alan Bem
+  Email: alan@example.com
+
+Copy to container? [Y/n]: y
+
+✓ Git config saved
+```
+
+### Storage and Persistence
+
+- **Location:** `/home/claude/.claude/.gitconfig` (in `dclaude-claude` volume)
+- **Environment:** `GIT_CONFIG_GLOBAL` points to this file
+- **Persistence:** Survives container stop/start, removal, and recreation
+- **Only deleted by:** `docker volume rm dclaude-claude`
+
+### Why This Is Needed
+
+SSH agent forwarding provides authentication (keys for push/pull), but git also needs identity configuration (name/email) for commits. The host's `~/.gitconfig` isn't mounted, so `dclaude git` bridges this gap by:
+1. Reading from host's git config
+2. Storing in the persistent volume
+3. Making it available via `GIT_CONFIG_GLOBAL` env var
+
 ## Tmux Session Management
 
 ### Architecture

--- a/dclaude
+++ b/dclaude
@@ -1776,6 +1776,94 @@ cmd_rm() {
     exit 0
 }
 
+# Subcommand: configure git identity
+cmd_git() {
+    local container_name=$(get_container_name "$HOST_PATH")
+
+    # Check if container exists
+    if ! docker ps -a --format '{{.Names}}' | grep -q "^${container_name}$"; then
+        error "No container found for this directory"
+        info "Run 'dclaude' first to create a container"
+        exit 1
+    fi
+
+    # Check if container is running
+    local container_status=$(docker inspect --format='{{.State.Status}}' "$container_name" 2>/dev/null)
+    if [[ "$container_status" != "running" ]]; then
+        if [[ "$container_status" == "exited" ]]; then
+            info "Starting container: $container_name"
+            docker start "$container_name" >/dev/null
+            sleep 1
+        else
+            error "Container $container_name is in unexpected state: $container_status"
+            exit 1
+        fi
+    fi
+
+    # Check if git config already exists
+    local existing_name existing_email
+    existing_name=$(docker exec -u claude "$container_name" git config --global user.name 2>/dev/null || echo "")
+    existing_email=$(docker exec -u claude "$container_name" git config --global user.email 2>/dev/null || echo "")
+
+    echo ""
+    echo "Git Configuration"
+    echo "─────────────────"
+
+    if [[ -n "$existing_name" && -n "$existing_email" ]]; then
+        echo "Current config:"
+        echo "  Name:  $existing_name"
+        echo "  Email: $existing_email"
+        echo ""
+        read -p "Update? [y/N]: " update
+        if [[ "$update" != "y" && "$update" != "Y" ]]; then
+            exit 0
+        fi
+    fi
+
+    # Try to get from host
+    local host_name host_email
+    host_name=$(git config --global user.name 2>/dev/null || echo "")
+    host_email=$(git config --global user.email 2>/dev/null || echo "")
+
+    local name="" email=""
+
+    if [[ -n "$host_name" && -n "$host_email" ]]; then
+        echo "Found on host:"
+        echo "  Name:  $host_name"
+        echo "  Email: $host_email"
+        echo ""
+        read -p "Copy to container? [Y/n]: " copy
+        if [[ "$copy" != "n" && "$copy" != "N" ]]; then
+            name="$host_name"
+            email="$host_email"
+        fi
+    fi
+
+    # Prompt if not copying from host
+    if [[ -z "$name" ]]; then
+        if [[ -z "$host_name" && -z "$host_email" ]]; then
+            echo "No git config found on host."
+            echo ""
+        fi
+        read -p "Enter your name: " name
+        read -p "Enter your email: " email
+    fi
+
+    # Validate
+    if [[ -z "$name" || -z "$email" ]]; then
+        error "Name and email are required"
+        exit 1
+    fi
+
+    # Save to container
+    docker exec -u claude "$container_name" git config --global user.name "$name"
+    docker exec -u claude "$container_name" git config --global user.email "$email"
+
+    echo ""
+    success "Git config saved"
+    exit 0
+}
+
 # Initialize HOST_PATH once for all commands
 HOST_PATH=$(get_host_path)
 
@@ -1823,6 +1911,10 @@ if [[ $# -gt 0 ]]; then
             shift
             cmd_ssh "$@"
             ;;
+        git)
+            shift
+            cmd_git "$@"
+            ;;
         --help|-h|help)
             cat << 'EOF'
 dclaude - Dockerized Claude Code Launcher
@@ -1836,6 +1928,7 @@ Usage:
   dclaude stop                Stop container for current directory
   dclaude rm [-f]             Remove container for current directory
   dclaude ssh                 Start SSH server for remote access
+  dclaude git                 Configure git identity (name/email)
   dclaude chrome [options]    Launch Chrome with DevTools and MCP integration
   dclaude gh                  Authenticate GitHub CLI (runs gh auth login)
   dclaude exec [command]      Execute command in container (default: bash)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -170,7 +170,8 @@ ENV CLAUDE_UNSAFE_TRUST_WORKSPACE=true \
     TERM=xterm-256color \
     LANG=en_US.UTF-8 \
     LC_ALL=en_US.UTF-8 \
-    LANGUAGE=en_US:en
+    LANGUAGE=en_US:en \
+    GIT_CONFIG_GLOBAL=/home/claude/.claude/.gitconfig
 
 # Labels
 LABEL maintainer="alanbem" \


### PR DESCRIPTION
## Summary

- Adds `dclaude git` subcommand to configure git identity (name/email) for commits made inside the container
- Adds `GIT_CONFIG_GLOBAL` env var in Dockerfile pointing to persistent volume
- Documents the feature and macOS SSH proxy architecture in CLAUDE.md

## Problem

SSH agent forwarding provides authentication (keys for push/pull), but git also needs identity configuration (name/email) for commits. The host's `~/.gitconfig` isn't mounted, so commits would fail with "Author identity unknown".

## Solution

New `dclaude git` command that:
- Detects existing config and offers to update
- Reads from host's git config and offers to copy
- Falls back to manual input
- Persists to `dclaude-claude` volume at `/home/claude/.claude/.gitconfig`

## Usage

```bash
dclaude git
```

## Test plan

- [x] Verify `GIT_CONFIG_GLOBAL` env var is set in container
- [x] Test copying config from host
- [x] Test config persistence (survives container recreation)
- [x] Test git operations with configured identity
- [x] Test SSH + git clone works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git configuration command to set up Git user identity and configuration within the container.

* **Documentation**
  * Expanded documentation with macOS SSH proxy architecture details and troubleshooting guidance.
  * Added comprehensive Git configuration flow and persistence documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->