### PR TITLE
fix: TTY detection failing inside command substitution subshell

### DIFF
--- a/dclaude
+++ b/dclaude
@@ -817,16 +817,22 @@ handle_git_auth() {
 }
 
 # Detect TTY availability and return appropriate Docker flags
+# Detect TTY status early (before any subshells)
+# Must be done at script top-level since $() subshells don't inherit TTY
+STDIN_IS_TTY=false
+STDOUT_IS_TTY=false
+[[ -t 0 ]] && STDIN_IS_TTY=true
+[[ -t 1 ]] && STDOUT_IS_TTY=true
+
 detect_tty_flags() {
     local tty_flags=""
 
-    # Check if stdin is a TTY
-    if [[ -t 0 ]]; then
+    # Use pre-detected TTY status (can't detect inside subshell)
+    if [[ "$STDIN_IS_TTY" == "true" ]]; then
         tty_flags="-i"
     fi
 
-    # Check if stdout is a TTY
-    if [[ -t 1 ]]; then
+    if [[ "$STDOUT_IS_TTY" == "true" ]]; then
         tty_flags="${tty_flags} -t"
     fi
 
@@ -834,7 +840,7 @@ detect_tty_flags() {
     tty_flags=$(echo $tty_flags | xargs)
 
     if [[ "$DEBUG" == "true" ]]; then
-        debug "TTY detection: stdin=$(test -t 0 && echo yes || echo no), stdout=$(test -t 1 && echo yes || echo no)"
+        debug "TTY detection: stdin=$STDIN_IS_TTY, stdout=$STDOUT_IS_TTY"
         debug "TTY flags: ${tty_flags:-none}"
     fi
 


### PR DESCRIPTION
## Summary

- Fixes TTY detection that was always returning `stdout=no` even in interactive terminals
- Root cause: `detect_tty_flags()` was called via `$()` subshell where stdout is a pipe, not a TTY

## Problem

```bash
local tty_flags=$(detect_tty_flags)  # <- subshell, stdout is a pipe!
```

Inside the subshell, `test -t 1` always returns false because stdout is redirected to capture the function output. This caused:
- Missing `-t` flag for docker exec
- tmux sessions failing to start properly
- `[exited]` immediately after "Starting new Claude session..."

## Solution

Detect TTY status at script top-level (before any subshells) and store in global variables:

```bash
STDIN_IS_TTY=false
STDOUT_IS_TTY=false
[[ -t 0 ]] && STDIN_IS_TTY=true
[[ -t 1 ]] && STDOUT_IS_TTY=true
```

## Test plan

- [x] Verify TTY detection shows `stdin=true, stdout=true` in interactive terminal
- [x] Verify tmux session starts correctly (no immediate `[exited]`)
- [x] Verify Claude runs properly inside the session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized terminal detection logic by moving TTY status checks to an early phase and consolidating inline checks.

* **Tests**
  * Enhanced debug logging to display detected terminal status information.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->