### PR TITLE
ci: scan only amd64 architecture for vulnerabilities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
+      # Note: QEMU not needed - we only scan amd64 (native on GitHub runners)
+      # Vulnerabilities are architecture-agnostic, no need to scan both arches
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -118,10 +116,11 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
-      - name: Build image for scanning
+      - name: Build image for scanning (amd64 only)
         uses: docker/build-push-action@v6
         with:
           context: docker
+          platforms: linux/amd64
           load: true
           tags: ${{ env.IMAGE_NAME }}:scan
           cache-from: type=gha


### PR DESCRIPTION
## Summary

- Remove QEMU setup from build-and-scan job (not needed for native amd64)
- Explicitly target only amd64 platform for scanning
- Vulnerabilities are architecture-agnostic, no need to scan both arches

## Performance Impact

Expected speedup in `build-and-scan` job:
- Removes QEMU emulation setup step (~10-20s)
- Makes platform targeting explicit (clearer intent)

## Test plan

- [ ] CI build passes
- [ ] Build-and-scan job completes faster than before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized continuous integration build workflow configuration for improved efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->