### PR TITLE
ci: merge scan and publish Docker jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,77 +89,10 @@ jobs:
           sarif_file: semgrep.sarif
           category: semgrep
 
-  build-and-scan:
-    name: Build and Scan
+  scan-and-publish-docker:
+    name: Scan and Publish Docker
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      # Note: QEMU not needed - we only scan amd64 (native on GitHub runners)
-      # Vulnerabilities are architecture-agnostic, no need to scan both arches
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Determine version
-        id: version
-        run: |
-          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
-            VERSION="${GITHUB_REF#refs/tags/v}"
-          else
-            VERSION="0.0.0-dev"
-          fi
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "Version: $VERSION"
-
-      - name: Build image for scanning (amd64 only)
-        uses: docker/build-push-action@v6
-        with:
-          context: docker
-          platforms: linux/amd64
-          load: true
-          tags: ${{ env.IMAGE_NAME }}:scan
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            VERSION=${{ steps.version.outputs.version }}
-
-      - name: Scan for vulnerabilities (console output)
-        uses: aquasecurity/trivy-action@0.33.1
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:scan
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-          scanners: 'vuln'
-
-      - name: Scan for vulnerabilities (SARIF)
-        uses: aquasecurity/trivy-action@0.33.1
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:scan
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-          scanners: 'vuln'
-
-      - name: Upload scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: trivy
-
-  publish-docker:
-    name: Publish Docker
-    runs-on: ubuntu-latest
-    needs: [lint, gitleaks, semgrep, build-and-scan, changes]
+    needs: [lint, gitleaks, semgrep, changes]
     # Run on tags (releases) OR when docker files changed on main branch
     if: |
       github.event_name != 'pull_request' &&
@@ -198,6 +131,50 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
+      # Build amd64 first for scanning (native, fast)
+      - name: Build amd64 for scanning
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+
+      # Scan for vulnerabilities - fails fast before building arm64
+      - name: Scan for vulnerabilities
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:scan
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          scanners: 'vuln'
+          exit-code: '1'
+
+      - name: Scan for vulnerabilities (SARIF)
+        uses: aquasecurity/trivy-action@0.33.1
+        if: always()
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:scan
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          scanners: 'vuln'
+
+      - name: Upload scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: trivy
+
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -214,6 +191,7 @@ jobs:
             # releases -> 'latest' tag (stable)
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
+      # Build both arches and push (amd64 uses cache from scan build)
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v6
@@ -250,7 +228,7 @@ jobs:
   publish-npm:
     name: Publish NPM
     runs-on: ubuntu-latest
-    needs: [lint, gitleaks, semgrep, build-and-scan]
+    needs: [lint, gitleaks, semgrep, scan-and-publish-docker]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- Consolidate `build-and-scan` and `publish-docker` into single `scan-and-publish-docker` job
- Build amd64 first (native, fast) for vulnerability scanning
- Fail early if critical/high vulnerabilities found before building arm64
- Only build arm64 and push if scan passes
- amd64 build cached and reused for final multi-arch push

## Performance Impact
Eliminates redundant Docker builds that were happening in separate jobs.

## Test plan
- [ ] CI workflow passes
- [ ] Compare build times with v0.0.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multi-architecture Docker image support for arm64 and amd64 platforms.
  * Introduced code signing for published Docker images.

* **Improvements**
  * Enhanced security through comprehensive vulnerability scanning in the build pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->