### PR TITLE
revert: ci merge scan+publish (caused regression)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,10 +89,77 @@ jobs:
           sarif_file: semgrep.sarif
           category: semgrep
 
-  scan-and-publish-docker:
-    name: Scan and Publish Docker
+  build-and-scan:
+    name: Build and Scan
     runs-on: ubuntu-latest
-    needs: [lint, gitleaks, semgrep, changes]
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      # Note: QEMU not needed - we only scan amd64 (native on GitHub runners)
+      # Vulnerabilities are architecture-agnostic, no need to scan both arches
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Determine version
+        id: version
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            VERSION="${GITHUB_REF#refs/tags/v}"
+          else
+            VERSION="0.0.0-dev"
+          fi
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Version: $VERSION"
+
+      - name: Build image for scanning (amd64 only)
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          platforms: linux/amd64
+          load: true
+          tags: ${{ env.IMAGE_NAME }}:scan
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+
+      - name: Scan for vulnerabilities (console output)
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:scan
+          format: 'table'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          scanners: 'vuln'
+
+      - name: Scan for vulnerabilities (SARIF)
+        uses: aquasecurity/trivy-action@0.33.1
+        with:
+          image-ref: ${{ env.IMAGE_NAME }}:scan
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          trivyignores: .trivyignore
+          scanners: 'vuln'
+
+      - name: Upload scan results to GitHub Security
+        uses: github/codeql-action/upload-sarif@v4
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+          category: trivy
+
+  publish-docker:
+    name: Publish Docker
+    runs-on: ubuntu-latest
+    needs: [lint, gitleaks, semgrep, build-and-scan, changes]
     # Run on tags (releases) OR when docker files changed on main branch
     if: |
       github.event_name != 'pull_request' &&
@@ -131,50 +198,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
 
-      # Build amd64 first for scanning (native, fast)
-      - name: Build amd64 for scanning
-        uses: docker/build-push-action@v6
-        with:
-          context: docker
-          platforms: linux/amd64
-          load: true
-          tags: ${{ env.IMAGE_NAME }}:scan
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            VERSION=${{ steps.version.outputs.version }}
-
-      # Scan for vulnerabilities - fails fast before building arm64
-      - name: Scan for vulnerabilities
-        uses: aquasecurity/trivy-action@0.33.1
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:scan
-          format: 'table'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-          scanners: 'vuln'
-          exit-code: '1'
-
-      - name: Scan for vulnerabilities (SARIF)
-        uses: aquasecurity/trivy-action@0.33.1
-        if: always()
-        with:
-          image-ref: ${{ env.IMAGE_NAME }}:scan
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          trivyignores: .trivyignore
-          scanners: 'vuln'
-
-      - name: Upload scan results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v4
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-          category: trivy
-
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -191,7 +214,6 @@ jobs:
             # releases -> 'latest' tag (stable)
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') }}
 
-      # Build both arches and push (amd64 uses cache from scan build)
       - name: Build and push Docker image
         id: build
         uses: docker/build-push-action@v6
@@ -228,7 +250,7 @@ jobs:
   publish-npm:
     name: Publish NPM
     runs-on: ubuntu-latest
-    needs: [lint, gitleaks, semgrep, scan-and-publish-docker]
+    needs: [lint, gitleaks, semgrep, build-and-scan]
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
Reverts PR #27 which merged the scan and publish Docker jobs.

The merged job was 1m 19s slower than separate jobs due to less efficient cache reuse within a single job vs across job boundaries.

| Version | Time |
|---------|------|
| v0.0.7 (separate jobs) | 13m 58s |
| v0.0.8 (merged job) | 15m 17s |

## Changes
- Restores `build-and-scan` job (amd64 only for vulnerability scanning)
- Restores `publish-docker` job (multi-arch build and push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow infrastructure for streamlined build, scanning, and deployment processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->