### PR TITLE
docs: add OrbStack VirtioFS cache troubleshooting

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,19 @@ ssh-add ~/.ssh/id_ed25519
 dclaude exec brew install <tool>  # This persists
 ```
 
+**Directories appear empty inside container? (OrbStack)**
+
+This is a [known OrbStack 2.0.x bug](https://github.com/orbstack/orbstack/issues/2103) where VirtioFS caches stale directory entries. Directories that existed before upgrading to OrbStack 2.0 may appear empty inside the container.
+
+```bash
+# Fix: rename the directory to clear the cache
+mv problematic-dir problematic-dir.tmp && mv problematic-dir.tmp problematic-dir
+
+# Or restart OrbStack completely (clears all caches)
+```
+
+Upgrading to the latest OrbStack version may also help.
+
 ## Project Structure
 
 ```text


### PR DESCRIPTION
## Summary

- Add troubleshooting entry for known OrbStack 2.0.x VirtioFS cache bug

## Context

When running dclaude with OrbStack on macOS, directories that existed before upgrading to OrbStack 2.0 may appear empty inside the container due to stale VirtioFS cache entries.

This is a [known OrbStack bug](https://github.com/orbstack/orbstack/issues/2103) affecting versions 2.0.x.

## Fix documented

1. Rename the directory to clear the cache: `mv dir dir.tmp && mv dir.tmp dir`
2. Or restart OrbStack completely

## Test plan

- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guidance for a known OrbStack 2.0.x issue where directories may appear empty inside containers, including practical workarounds and upgrade recommendations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->