### PR TITLE
feat: make tmux transparent for native terminal experience

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,6 +435,22 @@ SSH agent forwarding provides authentication (keys for push/pull), but git also 
 ### Architecture
 Persistent containers (`DCLAUDE_RM=false`, now the default) use tmux for session management. Each `dclaude` invocation creates a **new** tmux session with a unique name.
 
+### Maximum Transparency Mode
+
+Tmux is configured for maximum transparency so dclaude feels like a normal CLI application:
+
+- **No status bar** - `status off` hides the tmux status bar completely
+- **No mouse capture** - `mouse off` enables native terminal features
+- **No prefix key** - All keyboard input passes through to Claude
+- **No detach keys** - Users can't accidentally detach
+
+**Native terminal features work normally:**
+- Click-drag text selection
+- Cmd+C to copy (macOS) / Ctrl+Shift+C (Linux)
+- Cmd+F to search scrollback (iTerm2)
+- Native scroll gestures
+- Full keyboard pass-through
+
 ### Session Naming
 - **Default**: Auto-generated timestamp-based name (e.g., `claude-20231118-143022`)
 - **Custom**: Set via `DCLAUDE_TMUX_SESSION` environment variable (e.g., `claude-architect`)
@@ -458,41 +474,6 @@ set-option -g detach-on-destroy on
 - `escape-time 0` - Eliminates keyboard input delays
 - `aggressive-resize off` - Prevents input lag in multiple sessions
 - Simple `new-session` command without detach/attach pattern prevents double tmux processes that cause lag
-
-### Status Bar Design
-
-The tmux status bar displays environment context at the bottom of the screen.
-
-**Layout:**
-```
- net: HOST • dir: /path/to/dir      session: NAME      claude: 1.2.3 • image: local
- └─ left ─────────────────────┘     └─ center ─┘       └────────── right ─────────┘
-```
-
-**Design Principles:**
-1. **Theme-agnostic**: Works with both dark and light terminal themes
-2. **Claude branding**: Labels use Claude orange (#D97757)
-3. **Minimal footprint**: Single status line, no borders
-
-**Color Scheme:**
-| Element | Color | Rationale |
-|---------|-------|-----------|
-| Background | `terminal` | Matches user's terminal theme |
-| Labels | `#D97757` | Claude orange for branding |
-| Values | `terminal` | Adapts to user's theme (light/dark) |
-| Separators | `#D97757` | Orange dot (•) between attributes |
-
-**Internal Environment Variables:**
-These are passed via `docker exec -e` when creating tmux sessions:
-- `_DCLAUDE_NET` - Network mode (host/bridge)
-- `_DCLAUDE_TAG` - Docker image tag
-- `_DCLAUDE_SESSION` - Session name ("auto" or custom)
-
-**Adding New Attributes:**
-1. Pass new env var in dclaude script via `exec_env_args+=(-e "_DCLAUDE_NEWVAR=value")`
-2. Update `docker/home/claude/.tmux.conf` status-left/right with: `#[fg=#D97757]label: #[fg=terminal]#(printenv _DCLAUDE_NEWVAR || echo '?')`
-3. Use `•` separator between attributes in same section
-4. Rebuild image (tmux config is baked in)
 
 ### Session Lifecycle
 1. `dclaude` starts → Creates new tmux session → Runs Claude

--- a/dclaude
+++ b/dclaude
@@ -68,16 +68,6 @@ debug() {
     fi
 }
 
-# Reset terminal mouse mode after tmux exits
-# Prevents iTerm2 warnings about mouse reporting being left on
-reset_terminal_mouse() {
-    # Disable all mouse reporting modes:
-    # ?1000 - X10 mouse reporting
-    # ?1002 - Cell motion mouse tracking
-    # ?1003 - All motion mouse tracking
-    # ?1006 - SGR extended mouse reporting
-    printf '\033[?1000l\033[?1002l\033[?1003l\033[?1006l'
-}
 
 # Detect platform
 detect_platform() {
@@ -1034,18 +1024,12 @@ main() {
                 [[ -n "${TERM_PROGRAM_VERSION:-}" ]] && exec_env_args+=(-e "TERM_PROGRAM_VERSION=${TERM_PROGRAM_VERSION}")
                 [[ -n "${TERM_SESSION_ID:-}" ]] && exec_env_args+=(-e "TERM_SESSION_ID=${TERM_SESSION_ID}")
                 [[ -n "${COLORTERM:-}" ]] && exec_env_args+=(-e "COLORTERM=${COLORTERM}")
-                # Internal env vars for tmux status bar display
-                exec_env_args+=(-e "_DCLAUDE_NET=${network_mode}")
-                exec_env_args+=(-e "_DCLAUDE_TAG=${DCLAUDE_TAG:-latest}")
-                exec_env_args+=(-e "_DCLAUDE_SESSION=${DCLAUDE_TMUX_SESSION:-auto}")
 
                 debug "Creating new tmux session running Claude"
                 debug "Claude args count: ${#claude_args[@]}, user args: $*"
                 info "Starting new Claude session..."
                 docker exec -it -u claude "${exec_env_args[@]}" "$container_name" tmux -f /home/claude/.tmux.conf new-session -s "$tmux_session" claude "${claude_args[@]}" "$@"
-                local tmux_exit=$?
-                reset_terminal_mouse
-                exit $tmux_exit
+                exit $?
             else
                 # Non-interactive or print mode - run claude directly without tmux
                 debug "Non-interactive or print mode, running Claude directly (no tmux)"
@@ -1183,18 +1167,12 @@ main() {
             [[ -n "${TERM_PROGRAM_VERSION:-}" ]] && exec_env_args+=(-e "TERM_PROGRAM_VERSION=${TERM_PROGRAM_VERSION}")
             [[ -n "${TERM_SESSION_ID:-}" ]] && exec_env_args+=(-e "TERM_SESSION_ID=${TERM_SESSION_ID}")
             [[ -n "${COLORTERM:-}" ]] && exec_env_args+=(-e "COLORTERM=${COLORTERM}")
-            # Internal env vars for tmux status bar display
-            exec_env_args+=(-e "_DCLAUDE_NET=${network_mode}")
-            exec_env_args+=(-e "_DCLAUDE_TAG=${DCLAUDE_TAG:-latest}")
-            exec_env_args+=(-e "_DCLAUDE_SESSION=${DCLAUDE_TMUX_SESSION:-auto}")
 
             debug "Creating new tmux session running Claude"
             debug "Claude args count: ${#claude_args[@]}, user args: $*"
             info "Starting new Claude session..."
             docker exec -it -u claude "${exec_env_args[@]}" "$container_name" tmux -f /home/claude/.tmux.conf new-session -s "$tmux_session" claude "${claude_args[@]}" "$@"
-            local tmux_exit=$?
-            reset_terminal_mouse
-            exit $tmux_exit
+            exit $?
         else
             # Non-interactive or print mode - run claude directly without tmux
             debug "Non-interactive or print mode, running Claude directly (no tmux)"
@@ -1341,9 +1319,7 @@ cmd_attach() {
     # Attach to existing session
     info "Attaching to session: $session_name"
     docker exec -it -u claude "${exec_env_args[@]}" "$container_name" tmux -f /home/claude/.tmux.conf attach-session -t "$session_name"
-    local tmux_exit=$?
-    reset_terminal_mouse
-    exit $tmux_exit
+    exit $?
 }
 
 # Subcommand: launch Chrome with DevTools and ensure MCP configured

--- a/docker/home/claude/.tmux.conf
+++ b/docker/home/claude/.tmux.conf
@@ -1,5 +1,13 @@
-# dclaude tmux configuration - transparent mode
-# This makes tmux invisible to the user while keeping session persistence
+# dclaude tmux configuration - maximum transparency mode
+# Makes tmux invisible so dclaude feels like a normal CLI app, while
+# retaining session management benefits (multiple Claude instances in one container)
+#
+# Native terminal features work normally:
+# - Click-drag text selection
+# - Cmd+C to copy
+# - Cmd+F to search scrollback
+# - Native scroll gestures
+# - Full keyboard pass-through
 
 # Fix terminal compatibility
 set-option -g default-terminal "screen-256color"
@@ -21,8 +29,9 @@ set-option -g history-limit 50000
 # Allow alternate screen (Claude needs it)
 set-window-option -g alternate-screen on
 
-# Enable mouse support for iTerm2 native scrollback integration
-set-option -g mouse on
+# Disable mouse to enable native terminal features
+# With mouse off, the terminal handles selection, copy, and scrollback natively
+set-option -g mouse off
 
 # Disable visual bells but pass through audio bells
 set-option -g visual-activity off
@@ -43,38 +52,11 @@ unbind-key C-b
 set-option -g set-titles on
 set-option -g set-titles-string "Claude Code"
 
-# Status bar configuration
-# Style: dark background, orange labels/dividers, white values
-set-option -g status on
-set-option -g status-position bottom
-# Use terminal's own background color (blends with iTerm)
-set-option -g status-style "bg=default,fg=#D97757"
-set-option -g status-interval 60
-set-option -g status-left-length 100
-set-option -g status-right-length 80
-
-# Hide default window list
-set-window-option -g window-status-format ""
-set-window-option -g window-status-current-format ""
-
-# Left: net + dir
-# Labels: orange (#D97757), Values: terminal foreground, Separator: orange dot
-set-option -g status-left " net: #[fg=terminal]#(printenv _DCLAUDE_NET || echo '?')#[fg=#D97757] • dir: #[fg=terminal]#{pane_current_path}"
-
-# Center: session (via window-status-current)
-set-option -g status-justify centre
-set-window-option -g window-status-current-format "#[fg=#D97757]session: #[fg=terminal]#(printenv _DCLAUDE_SESSION || echo '?')"
-
-# Right: claude version + image
-set-option -g status-right "#[fg=#D97757]claude: #[fg=terminal]#(claude --version 2>/dev/null | grep -oE '[0-9]+\\.[0-9]+\\.[0-9]+' || echo '?') #[fg=#D97757]• image: #[fg=terminal]#(printenv _DCLAUDE_TAG || echo '?') "
-
+# Hide status bar completely for maximum transparency
+set-option -g status off
 
 # When the last pane exits, detach instead of switching sessions
 set-option -g detach-on-destroy on
 
 # Pass through all signals
 set-option -g remain-on-exit off
-
-# Reset terminal mouse mode on client detach to prevent iTerm2 warnings
-# about mouse reporting being left on
-set-hook -g client-detached 'run-shell "printf \"\033[?1000l\033[?1002l\033[?1003l\033[?1006l\""'


### PR DESCRIPTION
## Summary

Makes tmux invisible so dclaude feels like a normal CLI application, while retaining session management benefits (multiple Claude instances in one container).

**Changes:**
- Hide status bar completely (`status off`)
- Disable mouse capture (`mouse off`) to enable native terminal features
- Remove status bar env vars (`_DCLAUDE_NET`, `_DCLAUDE_TAG`, `_DCLAUDE_SESSION`)
- Remove `reset_terminal_mouse` function (not needed with mouse off)

## Native Terminal Features Now Working

| Feature | Before | After |
|---------|--------|-------|
| Text selection | tmux handled | Native click-drag |
| Copy | tmux copy mode | Cmd+C works |
| Search | Not available | Cmd+F works (iTerm2) |
| Scroll | tmux buffer | Native terminal scrollback |

## Test Plan

- [x] Verify no status bar appears
- [x] Verify text selection works (click-drag)
- [x] Verify copy works (Cmd+C after selection)
- [x] Verify scroll works (native terminal scroll)
- [x] Verify Cmd+F search works in iTerm2
- [x] Verify Claude CLI functions normally

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed session termination to properly return to terminal.

* **Documentation**
  * Introduced Maximum Transparency Mode enabling native terminal features (text selection, copy, search).
  * Clarified support for multiple concurrent sessions within containers.
  * Enhanced session management and lifecycle documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->