### PR TITLE
docs: add guidance for comprehensive release notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -853,6 +853,20 @@ gh release create v1.2.3 --title "v1.2.3" --notes "Release notes here"
 
 **Version source of truth:** Git tags (no VERSION file)
 
+**Release notes must include ALL changes since last release:**
+```bash
+# Check what commits are included in the release
+git fetch --tags
+git log v0.0.9..HEAD --oneline  # Replace v0.0.9 with last release tag
+
+# Look for merged PRs and group changes by:
+# - New features (feat:)
+# - Bug fixes (fix:)
+# - Documentation (docs:)
+# - Refactoring (refactor:)
+# - Other changes (chore:, etc.)
+```
+
 **Local development:**
 ```bash
 make build           # Build local image


### PR DESCRIPTION
## Summary

Add guidance to CLAUDE.md about creating release notes that include ALL changes between releases, not just the latest PR.

## Changes

- Added instructions to check commits between releases using `git log`
- Added guidance to group changes by type (feat, fix, docs, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)