### PR TITLE
fix: auto-start SSH proxy when reattaching to containers

### DIFF
--- a/dclaude
+++ b/dclaude
@@ -1214,6 +1214,16 @@ main() {
                 done
             fi
 
+            # Ensure SSH proxy is running if container uses agent forwarding (macOS)
+            if [[ "$platform" == "darwin" ]]; then
+                local container_ssh_sock
+                container_ssh_sock=$(docker inspect --format='{{range .Config.Env}}{{println .}}{{end}}' "$container_name" 2>/dev/null | grep "^SSH_AUTH_SOCK=" | cut -d= -f2)
+                if [[ "$container_ssh_sock" == "/tmp/ssh-proxy/agent" ]]; then
+                    debug "Container uses SSH agent forwarding, ensuring proxy is running"
+                    setup_ssh_proxy_container
+                fi
+            fi
+
             # Check if interactive (TTY available) and not in print mode
             if [[ -n "$tty_flags" ]] && ! should_skip_tmux "${claude_args[@]}" "$@"; then
                 # Interactive and not print mode - use tmux for session management


### PR DESCRIPTION
## Summary

Fix SSH agent forwarding not working after Docker/OrbStack restarts.

When reusing an existing container on macOS, dclaude now checks if it was configured with SSH agent forwarding and ensures the proxy container is running before attaching.

## Problem

1. User starts dclaude → container created with SSH agent forwarding
2. User restarts OrbStack/Docker → SSH proxy container dies
3. User runs dclaude again → reattaches to existing container
4. **Bug**: SSH doesn't work because proxy is dead and dclaude didn't restart it

## Solution

Before attaching to an existing container, check if it uses SSH agent forwarding (`SSH_AUTH_SOCK=/tmp/ssh-proxy/agent`) and call `setup_ssh_proxy_container()` to ensure the proxy is running.

## Test plan

- [x] Kill OrbStack, restart it
- [x] Run dclaude from a directory with existing container
- [x] Verify SSH proxy auto-starts
- [x] Verify SSH keys are accessible inside container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced macOS support for SSH agent forwarding in containers
  * Automatic SSH proxy initialization when containers require SSH agent forwarding

<!-- end of auto-generated comment: release notes by coderabbit.ai -->