### PR TITLE
chore: rename ci.yml to ci-cd.yml

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI/CD
 
 on:
   push:


### PR DESCRIPTION
## Summary
- Renames `.github/workflows/ci.yml` → `.github/workflows/ci-cd.yml`
- Updates workflow name from `CI` to `CI/CD`
- Reflects that the workflow contains both CI (lint, scan, build) and CD (publish Docker, publish npm) jobs

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow display name for improved clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->