### PR TITLE
feat: CA certificate support for corporate SSL inspection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ dclaude supports a `.dclaude` config file that applies settings recursively to a
 - `CHROME_PORT` - Chrome DevTools port
 - `MOUNT_ROOT` - Mount directory (relative to config file, or absolute path)
 - `AWS_CLI` - AWS config mode (`mount`, `volume`, `none`)
+- `CA_CERT` - Path to CA certificate for corporate SSL inspection (relative to config file, or absolute)
 
 **Note:** Chrome profiles are stored in `.dclaude.d/` directory, keeping `.dclaude` available for the config file.
 

--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ dclaude shell                     # Open a bash shell (alias for exec)
 | `DCLAUDE_AWS_CLI` | `auto` | AWS config: `auto`, `mount`, `volume`, `none` |
 | `DCLAUDE_TMUX_SESSION` | `claude-TIMESTAMP` | Custom tmux session name for concurrent sessions |
 | `DCLAUDE_ITERM2` | `true` | Enable iTerm2 shell integration (only affects iTerm2) |
+| `DCLAUDE_CA_CERT` | (none) | Path to CA certificate for corporate SSL inspection |
 
 ## Configuration File
 
@@ -275,6 +276,7 @@ Create a `.dclaude` file at your project root to configure dclaude for that dire
 NAMESPACE=mycompany
 NETWORK=host
 DEBUG=true
+CA_CERT=certs/corporate-ca.pem
 ```
 
 dclaude walks up the directory tree to find `.dclaude` files. Any dclaude session started from that directory or any subdirectory will use these settings.
@@ -290,6 +292,7 @@ dclaude walks up the directory tree to find `.dclaude` files. Any dclaude sessio
 | `DEBUG` | Enable debug output (`true`, `false`) |
 | `CHROME_PORT` | Chrome DevTools port |
 | `AWS_CLI` | AWS config mode (`mount`, `volume`, `none`) |
+| `CA_CERT` | Path to CA certificate for corporate SSL inspection (relative to config file, or absolute) |
 
 Config file variables are the unprefixed equivalents of `DCLAUDE_*` environment variables (e.g., `NAMESPACE` in `.dclaude` = `DCLAUDE_NAMESPACE` env var).
 

--- a/dclaude
+++ b/dclaude
@@ -169,7 +169,7 @@ CHROME_PORT="${DCLAUDE_CHROME_PORT:-9222}"
 readonly AWS_CLI_MODE="${DCLAUDE_AWS_CLI:-auto}"  # auto, mount, volume, none
 # Resolve CA_CERT relative paths (env var: relative to PWD, config file: already resolved)
 if [[ -n "${DCLAUDE_CA_CERT:-}" && "${DCLAUDE_CA_CERT}" != /* ]]; then
-    DCLAUDE_CA_CERT=$(realpath "$DCLAUDE_CA_CERT" 2>/dev/null) || true
+    DCLAUDE_CA_CERT=$(realpath "$DCLAUDE_CA_CERT" 2>/dev/null) || DCLAUDE_CA_CERT="$PWD/$DCLAUDE_CA_CERT"
 fi
 readonly CA_CERT="${DCLAUDE_CA_CERT:-}"  # Path to CA certificate for corporate proxies
 

--- a/dclaude
+++ b/dclaude
@@ -138,6 +138,18 @@ load_config_file() {
                 AWS_CLI)
                     [[ -z "${DCLAUDE_AWS_CLI:-}" ]] && DCLAUDE_AWS_CLI="$value"
                     ;;
+                CA_CERT)
+                    if [[ -z "${DCLAUDE_CA_CERT:-}" ]]; then
+                        # Resolve relative paths relative to config file's directory
+                        if [[ "$value" != /* ]]; then
+                            local config_dir
+                            config_dir=$(dirname "$config_file")
+                            DCLAUDE_CA_CERT=$(cd "$config_dir" && realpath "$value" 2>/dev/null)
+                        else
+                            DCLAUDE_CA_CERT="$value"
+                        fi
+                    fi
+                    ;;
             esac
         fi
     done < "$config_file"
@@ -155,6 +167,11 @@ readonly GIT_AUTH_MODE="${DCLAUDE_GIT_AUTH:-auto}"  # auto, agent-forwarding, ke
 readonly NAMESPACE="${DCLAUDE_NAMESPACE:-}"
 CHROME_PORT="${DCLAUDE_CHROME_PORT:-9222}"
 readonly AWS_CLI_MODE="${DCLAUDE_AWS_CLI:-auto}"  # auto, mount, volume, none
+# Resolve CA_CERT relative paths (env var: relative to PWD, config file: already resolved)
+if [[ -n "${DCLAUDE_CA_CERT:-}" && "${DCLAUDE_CA_CERT}" != /* ]]; then
+    DCLAUDE_CA_CERT=$(realpath "$DCLAUDE_CA_CERT" 2>/dev/null) || true
+fi
+readonly CA_CERT="${DCLAUDE_CA_CERT:-}"  # Path to CA certificate for corporate proxies
 
 # Show config file if loaded (always at info level, details at debug)
 if [[ -n "$DCLAUDE_CONFIG_FILE" ]]; then
@@ -166,6 +183,7 @@ if [[ -n "$DCLAUDE_CONFIG_FILE" ]]; then
         [[ -n "${DCLAUDE_CHROME_PORT:-}" ]] && debug "  CHROME_PORT=$DCLAUDE_CHROME_PORT"
         [[ -n "${DCLAUDE_MOUNT_ROOT:-}" ]] && debug "  MOUNT_ROOT=$DCLAUDE_MOUNT_ROOT"
         [[ -n "${DCLAUDE_AWS_CLI:-}" ]] && debug "  AWS_CLI=$DCLAUDE_AWS_CLI"
+        [[ -n "$CA_CERT" ]] && debug "  CA_CERT=$CA_CERT"
     fi
 fi
 
@@ -1913,6 +1931,23 @@ main() {
             debug "AWS CLI config mounting disabled"
             ;;
     esac
+
+    # Handle CA certificate for corporate proxies / SSL inspection
+    # The cert file must be within the mounted directory tree to be accessible inside the container
+    if [[ -n "$CA_CERT" ]]; then
+        if [[ ! -f "$CA_CERT" ]]; then
+            warning "CA certificate not found: $CA_CERT"
+        elif [[ "$CA_CERT" != "$MOUNT_ROOT"* ]]; then
+            warning "CA certificate is outside the mounted directory: $CA_CERT"
+            warning "It must be within: $MOUNT_ROOT"
+        else
+            DOCKER_ARGS+=(
+                -e "NODE_EXTRA_CA_CERTS=${CA_CERT}"
+                -e "SSL_CERT_FILE=${CA_CERT}"
+            )
+            info "CA certificate: $CA_CERT"
+        fi
+    fi
 
     # Add any additional environment variables
     if [[ -n "${CLAUDE_MODEL:-}" ]]; then


### PR DESCRIPTION
## Summary

- Adds `CA_CERT` config variable (`.dclaude` file) and `DCLAUDE_CA_CERT` env var for corporate environments with SSL inspection proxies
- Sets `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` inside the container so Claude Code, npm, curl, and Python all trust the corporate CA
- Resolves relative paths (from config file dir or working dir) and validates the cert is within the mounted directory tree

## Usage

```bash
# .dclaude config file
CA_CERT=multitude-ca.pem
```

or

```bash
DCLAUDE_CA_CERT=./multitude-ca.pem dclaude
```

## Test plan

- [ ] `DCLAUDE_CA_CERT=./some-cert.pem dclaude` sets `NODE_EXTRA_CA_CERTS` and `SSL_CERT_FILE` inside container
- [ ] `CA_CERT=cert.pem` in `.dclaude` config resolves relative to config file directory
- [ ] Warning shown if cert file not found
- [ ] Warning shown if cert is outside mounted directory
- [ ] No changes to Docker image required — script-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added custom CA certificate support for corporate SSL inspection. Users can set it via DCLAUDE_CA_CERT (env) or CA_CERT in .dclaude.
  * Relative paths are resolved to absolute; valid certs are injected into launched containers so apps use the certificate.

* **Documentation**
  * Updated docs and examples to show new configuration options and usage.

* **Behavior**
  * Missing or out-of-tree certs produce warnings and are not injected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->